### PR TITLE
suggested patchfix for end of winter breaking via improvements

### DIFF
--- a/NoCrash DLL SourceCode/CvPlot.cpp
+++ b/NoCrash DLL SourceCode/CvPlot.cpp
@@ -7851,7 +7851,7 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue)
 		{
 			GC.getMapINLINE().getArea(getArea())->changeNumEvilTiles(bEvilPre ? -1 : 1);
 		}
-		if (!GC.getGameINLINE().isOption(GAMEOPTION_NO_PLOT_COUNTER))
+		if (!GC.getGameINLINE().isOption(GAMEOPTION_NO_PLOT_COUNTER) && getTempTerrainTimer() < 0)
 		{
 			TerrainTypes terrainType = (TerrainTypes)getTerrainType();
 			FAssert(terrainType != NO_TERRAIN);


### PR DESCRIPTION
From what I can tell there is some inconsistency in how natural terrrain, hell terrain, and temporary terrain intersect; I am not confident this won't introduce other edgecase oddities, but it does fix the issue where early workers will penalize you in end of winter by locking you into terrain.