### PR TITLE
kaczkar123 Water Walking changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ bld/
 [Oo]ut/
 [Ll]og/
 [Ll]ogs/
+#libraries
+Boost-1.32.0/
+Python24/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/NoCrash DLL SourceCode/CvUnit.cpp
+++ b/NoCrash DLL SourceCode/CvUnit.cpp
@@ -5104,7 +5104,7 @@ bool CvUnit::canMoveInto(const CvPlot* pPlot, bool bAttack, bool bDeclareWar, bo
 			TechTypes eTech = (TechTypes)m_pUnitInfo->getTerrainPassableTech(pPlot->getTerrainType());
 			if (NO_TECH == eTech || !GET_TEAM(getTeam()).isHasTech(eTech))
 			{
-				if (DOMAIN_SEA != getDomainType() || pPlot->getTeam() != getTeam())  // sea units can enter impassable in own cultural borders
+				if ((!(pPlot->isWater() && canMoveAllTerrain()) && DOMAIN_SEA != getDomainType()) || pPlot->getTeam() != getTeam())  // sea units can enter impassable in own cultural borders
 				{
 					if (bIgnoreLoad || !canLoad(pPlot))
 					{

--- a/NoCrash DLL SourceCode/CvUnitAI.cpp
+++ b/NoCrash DLL SourceCode/CvUnitAI.cpp
@@ -22850,7 +22850,7 @@ bool CvUnitAI::AI_improveBonus(int iMinValue, CvPlot** ppBestPlot, BuildTypes* p
 			bool bCanImprove = (pLoopPlot->area() == area());
 			if (!bCanImprove)
 			{
-				if (DOMAIN_SEA == getDomainType() && pLoopPlot->isWater() && plot()->isAdjacentToArea(pLoopPlot->area()))
+				if ((DOMAIN_SEA == getDomainType() || canMoveAllTerrain()) && pLoopPlot->isWater() && plot()->isAdjacentToArea(pLoopPlot->area()))
 				{
 					bCanImprove = true;
 				}


### PR DESCRIPTION
Units with water walking can access ocean/deep ocean within team borders in the same way workboats can.
Fixed water walking workers AI not seeing water resources when on land.
