### PR TITLE
Fix tooltip for Ignore-Building-Defense promotions (#438)

### DIFF
--- a/Assets/XML/Text/CIV4GameText_Promotions.xml
+++ b/Assets/XML/Text/CIV4GameText_Promotions.xml
@@ -2463,11 +2463,11 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_PROMOTION_IGNORE_BUILDING_DEFENSE</Tag>
-		<English>[ICON_BULLET]Ignores terrain defense</English>
-		<French>[ICON_BULLET]Ignore la défense due au terrain</French>
-		<German>[ICON_BULLET]Ignoriert Geländeverteidigung</German>
-		<Italian>[ICON_BULLET]Ignores terrain defense</Italian>
-		<Spanish>[ICON_BULLET]Ignores terrain defense</Spanish>
+		<English>[ICON_BULLET]Ignores building defense</English>
+		<French>[ICON_BULLET]Ignore la défense due aux bâtiments</French>
+		<German>[ICON_BULLET]Ignoriert Gebäudeverteidigung</German>
+		<Italian>[ICON_BULLET]Ignores building defense</Italian>
+		<Spanish>[ICON_BULLET]Ignores building defense</Spanish>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_PROMOTION_ILLUSION</Tag>


### PR DESCRIPTION
The bIgnoreBuildingDefense flag — used by PROMOTION_GCF_SUBTERFUGE (Council of Esus Subterfuge) and PROMOTION_SHADOWWALK — only affects defense from in-city buildings (walls, castles).  See CvPlot.cpp, CvPlot::defenseModifier:

    iModifier = (feature ? feature.def : terrain.def);
    if (isHills()) iModifier += HILLS_EXTRA_DEFENSE;   // <- always
    ...
    if (pCity != NULL)
        iModifier += pCity->getDefenseModifier(bIgnoreBuilding);
                                              // ^^^^^^^^^^^^^^^ only here

The TXT_KEY_PROMOTION_IGNORE_BUILDING_DEFENSE string however reads "Ignores terrain defense", which made players reasonably expect the +25% hill bonus to be bypassed — it never was.

This commit aligns the displayed text with what the code does. English/Italian/Spanish (the last two were English-placeholder lines already) now say "Ignores building defense"; French and German get "bâtiments" / "Gebäude" translations to match.

No DLL or gameplay change.

Refs: black-imperator/AoEDev#438