### PR TITLE
Fix Broader-Alignment drift accumulator typo (#389)

### DIFF
--- a/NoCrash DLL SourceCode/CvPlayer.cpp
+++ b/NoCrash DLL SourceCode/CvPlayer.cpp
@@ -29094,7 +29094,7 @@ void CvPlayer::setBroadShiftAmount(int iNewValue)
 }
 void CvPlayer::changeBroadShiftAmount(int iChange)
 {
-	if (iChange !=0) m_iBroadShiftAmount = m_iBroadShiftTurns + iChange;
+	if (iChange !=0) m_iBroadShiftAmount = m_iBroadShiftAmount + iChange;
 }
 int CvPlayer::getBroadShiftTurns() const
 {
@@ -29554,7 +29554,7 @@ void CvPlayer::setBroadEthicalShiftAmount(int iNewValue)
 }
 void CvPlayer::changeBroadEthicalShiftAmount(int iChange)
 {
-	if (iChange !=0) m_iBroadEthicalShiftAmount = m_iBroadEthicalShiftTurns + iChange;
+	if (iChange !=0) m_iBroadEthicalShiftAmount = m_iBroadEthicalShiftAmount + iChange;
 }
 int CvPlayer::getBroadEthicalShiftTurns() const
 {


### PR DESCRIPTION
Closes #389.

## Root cause

Two identical typos in `CvPlayer.cpp` accumulator-style setters leave the sliding-scale alignment unable to drift over time:

```cpp
// CvPlayer::changeBroadShiftAmount (CvPlayer.cpp:29097)
void CvPlayer::changeBroadShiftAmount(int iChange)
{
    if (iChange !=0) m_iBroadShiftAmount = m_iBroadShiftTurns + iChange;
                                           ^^^^^^^^^^^^^^^^^^^^ wrong RHS — should be m_iBroadShiftAmount
}
```

`updateAlignmentShift` calls this every `BROADER_ALIGNMENT_INCREASE_RATE` turns to fold the per-turn drift into `BroadShiftAmount`. Because the RHS reads `m_iBroadShiftTurns` instead of `m_iBroadShiftAmount`, `Amount` gets **overwritten** with `(Turns + increase)` each cycle rather than accumulating across cycles. `updateAlignment` then adds `BroadShiftAmount` into `BroadAlignment`, so the slider never moves more than one cycle's worth of drift.

`changeBroadEthicalShiftAmount` has the same typo on the Lawful-Chaotic axis (Valkrionn's 2009 expansion) and is fixed identically.

## The fix

Two-line correction. RHS reads `Amount` instead of `Turns`. No XML or data changes.

Existing `<iAlignmentModifier>` data on leaders (98), religions (6), and civics (8) — which is loaded into `CvLeaderHeadInfo` / `CvReligionInfo` / `CvCivicInfo` today but inert because the accumulator was broken — starts working again with this fix.

## Notes

* The `iAlignmentShiftModifier` schema is declared for Buildings / Units / Civics / Religions but only Religions have any populated values, so per-turn drift comes only from the state religion. That's a separate design question (backfilling shift modifiers on Buildings/Units/Civics) — out of scope for this PR.
* The `bIgnoreBuildingDefense` tooltip fix from #438 also went through `CvPlayer.cpp` adjacent areas; this change is independent and on a separate branch.