### PR TITLE
Strip incompatible features inside setTerrainType (#388)

### DIFF
--- a/NoCrash DLL SourceCode/CvPlot.cpp
+++ b/NoCrash DLL SourceCode/CvPlot.cpp
@@ -6896,6 +6896,17 @@ void CvPlot::setTerrainType(TerrainTypes eNewValue, bool bRecalculate, bool bReb
 		updateSeeFromSight(true, true);
 	}
 
+	// Bugfix: strip an incompatible feature when the terrain changes.
+	// Without this, any setTerrainType-driven transition (setTempTerrainType,
+	// terraforming spells, plot-counter hellification, worldbuilder) can
+	// leave a feature in place that's invalid on the new terrain -- e.g.
+	// FLOODPLAINS surviving a Desert->Wasteland transition.
+	if (getFeatureType() != NO_FEATURE
+	 && !GC.getFeatureInfo(getFeatureType()).isTerrain(getTerrainType()))
+	{
+		setFeatureType(NO_FEATURE);
+	}
+
 	updateYield();
 	updatePlotGroup();
 
@@ -13337,14 +13348,7 @@ void CvPlot::changePlotCounter(int iChange)
 	{
 		setTerrainType((TerrainTypes)GC.getTerrainClassInfo(getTerrainClassType()).getNaturalTerrain(), false, true);
 	}
-
-	if (getFeatureType() != NO_FEATURE)
-	{
-		if (!GC.getFeatureInfo(getFeatureType()).isTerrain(getTerrainType()))
-		{
-			setFeatureType(NO_FEATURE);
-		}
-	}
+	// Feature compatibility is enforced inside setTerrainType itself.
 }
 
 void CvPlot::setPlotCounter(int iNewValue)


### PR DESCRIPTION
Closes #388.

## Root cause

`FEATURE_FLOOD_PLAINS` only lists `TERRAIN_DESERT` as a valid host terrain in `CIV4FeatureInfos.xml` (`<TerrainBooleans>` block) — on Wasteland it's invalid by design. The DLL is supposed to strip such mismatched features when terrain changes, but the cleanup lives in only **one** of the terrain-change paths:

```cpp
// CvPlot::changePlotCounter (CvPlot.cpp:13341-13347) — has the cleanup
if (bEvilPre != bEvilPost) {
    setTerrainType(...);
    if (getFeatureType() != NO_FEATURE
        && !GC.getFeatureInfo(getFeatureType()).isTerrain(getTerrainType())) {
        setFeatureType(NO_FEATURE);
    }
}
```

Every other path that mutates terrain — `setTempTerrainType`, `setTempTerrainTypeFM`, `setTerrainClassType`, terraforming spells like `postCombatWinDteshAffinityEntropy` (`CvSpellInterface.py:8552-8555` does `pPlot.setTempTerrainType(iWasteland, 10)`), and worldbuilder direct assignments — calls `setTerrainType` without the reconciliation, so the floodplains feature stays put on a now-Wasteland tile.

That matches the issue's symptom exactly for the terraforming case, and explains the around-Well-of-Souls case when Wasteland was placed via any non-plot-counter route (or when a transition happens to not flip the `bEvilPre != bEvilPost` boundary).

## The fix

Lift the cleanup into `CvPlot::setTerrainType` itself, so every caller benefits uniformly. Placed after `m_eTerrainType` is assigned and after the sight update, but before `updateYield()` / `updatePlotGroup()` so those compute against the corrected feature.

```cpp
// In CvPlot::setTerrainType, after sight update:
if (getFeatureType() != NO_FEATURE
    && !GC.getFeatureInfo(getFeatureType()).isTerrain(getTerrainType()))
{
    setFeatureType(NO_FEATURE);
}
```

Removed the duplicated block from `changePlotCounter` to keep the invariant in one place.

## Scope / risk

After this PR, every terrain mutation path — `setTerrainType`, `setTempTerrainType`, `setTempTerrainTypeFM`, `setTerrainClassType`, plot-counter hellification, worldbuilder, direct DLL/Python calls — strips an invalid feature uniformly. This is the correct invariant; any existing place that relied on a mismatched terrain+feature pair surviving a `setTerrainType` call was buggy anyway.

No XML / data changes.