### PR TITLE
Fix Baby Boom firing without a prior war (#382)

### DIFF
--- a/Assets/python/entrypoints/CvRandomEventInterface.py
+++ b/Assets/python/entrypoints/CvRandomEventInterface.py
@@ -3487,7 +3487,12 @@ def canTriggerBabyBoom(argsList):
 
 	for iLoopTeam in range(gc.getMAX_CIV_TEAMS()):
 		if iLoopTeam != iTeam:
-			if pTeam.AI_getAtPeaceCounter(iLoopTeam) == 1:
+			# Bugfix #382: AtPeaceCounter resets to 0 on declareWar and starts
+			# at 0 on first meeting.  AtPeace == 1 alone matches both "just made
+			# peace" and "just met".  Require HasMet > AtPeace so a war must
+			# have happened between meeting and now.
+			if (pTeam.AI_getAtPeaceCounter(iLoopTeam) == 1
+			 and pTeam.AI_getHasMetCounter(iLoopTeam) > pTeam.AI_getAtPeaceCounter(iLoopTeam)):
 				return True
 
 	return False

--- a/NoCrash DLL SourceCode/CyTeam.cpp
+++ b/NoCrash DLL SourceCode/CyTeam.cpp
@@ -989,6 +989,11 @@ int CyTeam::AI_getWarSuccess(int /*TeamTypes*/ eIndex) const
 {
 	return m_pTeam ? m_pTeam->AI_getWarSuccess((TeamTypes)eIndex) : -1;
 }
+
+int CyTeam::AI_getHasMetCounter(int /*TeamTypes*/ eTeam) const
+{
+	return m_pTeam ? m_pTeam->AI_getHasMetCounter((TeamTypes)eTeam) : -1;
+}
 /*************************************************************************************************/
 /**	New Tag Defs	(ProjectInfos)			09/12/08								Xienwolf	**/
 /**	New Tag Defs	(TeamInfos)				09/12/08											**/

--- a/NoCrash DLL SourceCode/CyTeam.h
+++ b/NoCrash DLL SourceCode/CyTeam.h
@@ -230,6 +230,7 @@ public:
 	int AI_getAtWarCounter(int /*TeamTypes*/ eTeam) const;
 	int AI_getAtPeaceCounter(int /*TeamTypes*/ eTeam) const;
 	int AI_getWarSuccess(int /*TeamTypes*/ eIndex) const;
+	int AI_getHasMetCounter(int /*TeamTypes*/ eTeam) const;
 /*************************************************************************************************/
 /**	New Tag Defs	(ProjectInfos)			09/12/08								Xienwolf	**/
 /**	New Tag Defs	(TeamInfos)				09/12/08											**/

--- a/NoCrash DLL SourceCode/CyTeamInterface.cpp
+++ b/NoCrash DLL SourceCode/CyTeamInterface.cpp
@@ -222,6 +222,7 @@ void CyTeamPythonInterface()
 		.def("AI_getAtWarCounter", &CyTeam::AI_getAtWarCounter, "int (TeamTypes)")
 		.def("AI_getAtPeaceCounter", &CyTeam::AI_getAtPeaceCounter, "int (TeamTypes)")
 		.def("AI_getWarSuccess", &CyTeam::AI_getWarSuccess, "int (TeamTypes)")
+		.def("AI_getHasMetCounter", &CyTeam::AI_getHasMetCounter, "int (TeamTypes)")
 /*************************************************************************************************/
 /**	New Tag Defs	(ProjectInfos)			09/12/08								Xienwolf	**/
 /**	New Tag Defs	(TeamInfos)				09/12/08											**/


### PR DESCRIPTION
Closes #382.

## Repro

`EVENTTRIGGER_BABY_BOOM` (vanilla BTS event, inherited by AoE) fires on a young turn with no wars in the game's history. The trigger text is `"Our soldiers, returning from war, have dedicated themselves to peace..."`. No soldiers, no war. Reporter hit it on turn 38.

## Root cause

The trigger is gated by `canTriggerBabyBoom()` in `Assets/python/entrypoints/CvRandomEventInterface.py:3475-3493`:

```python
if pTeam.getAtWarCount(True) > 0:
    return False
for iLoopTeam in range(gc.getMAX_CIV_TEAMS()):
    if iLoopTeam != iTeam:
        if pTeam.AI_getAtPeaceCounter(iLoopTeam) == 1:
            return True
```

The intent is "we just made peace last turn." But `AI_getAtPeaceCounter` zeros in **two** places:

1. **`CvTeam::declareWar`** (`CvTeam.cpp:1480-1481`) sets both sides to 0, so `AtPeace == 1` the turn after peace is signed.
2. **Before first contact** the counter is 0; `CvTeamAI::AI_doCounter` only increments it once `isHasMet` is true (the LeadersEnhanced refinement at `CvTeamAI.cpp:4319-4322`). So `AtPeace == 1` *also* matches the turn after first meeting a new civ.

Whenever you meet a new civ on turn N, you can trigger Baby Boom on turn N+1 with no war ever having existed in the game.

## Fix

Require `pTeam.AI_getHasMetCounter(iLoopTeam) > pTeam.AI_getAtPeaceCounter(iLoopTeam)`.

`AI_getHasMetCounter` increments every turn after first contact and is *never reset*, while `AI_getAtPeaceCounter` is zeroed by `declareWar`. So:

- Never warred, just met → both counters tick together → `HasMet == AtPeace`, predicate fails.
- War happened between meeting and now → AtPeace was zeroed during war while HasMet kept ticking → `HasMet > AtPeace`, predicate holds.

In plain English: \"we have been at war with this team between first meeting them and now.\"

## Cy* binding

`AI_getHasMetCounter` was the one signal I needed and it isn't currently exposed to Python on `CyTeam`. Added a 3-line Boost.Python binding mirroring the adjacent `AI_getAtPeaceCounter` / `AI_getWarSuccess`:

- decl in `CyTeam.h:233`
- impl in `CyTeam.cpp` after `AI_getWarSuccess`
- `.def(\"AI_getHasMetCounter\", ...)` in `CyTeamInterface.cpp:225`

No behavior change for any existing caller; just exposes a const getter that's already on the C++ `CvTeamAI`.

## Scope

* Python diff: 2 lines of new logic + 4 lines of comment in `canTriggerBabyBoom`.
* DLL diff: 3 lines (decl + 4-line impl + binding).
* No XML / data changes.