### PR TITLE
Fix Ram of Vir not healing the killer (#435)

### DIFF
--- a/Assets/python/entrypoints/CvSpellInterface.py
+++ b/Assets/python/entrypoints/CvSpellInterface.py
@@ -809,6 +809,11 @@ def postCombatLostRamVir(pCaster, pOpponent):
 	iPlayer = pOpponent.getOwner()
 	pPlayer = gc.getPlayer(iPlayer)
 	if (pOpponent.isAlive()):
+		# Bugfix (#435): pedia/help text (TXT_KEY_UNIT_RAM_OF_VIR_HELP)
+		# promises "Units who Kill a Ram of Vir get fully healed."  The
+		# previous implementation only cleared negative-status promotions;
+		# the damage was never reset.
+		pOpponent.setDamage(0, -1)
 		pOpponent.setHasPromotion(getInfoType("PROMOTION_CRAZED"),False)
 		pOpponent.setHasPromotion(getInfoType("PROMOTION_DISEASED"),False)
 		pOpponent.setHasPromotion(getInfoType("PROMOTION_ENERVATED"),False)
@@ -819,7 +824,6 @@ def postCombatLostRamVir(pCaster, pOpponent):
 		pOpponent.setHasPromotion(getInfoType("PROMOTION_UNWHOLESOME_ADDICTION"),False)
 		pOpponent.setHasPromotion(getInfoType("PROMOTION_WINTERED"),False)
 		pOpponent.setHasPromotion(getInfoType("PROMOTION_WITHERED"),False)
-		pOpponent.setHasPromotion(getInfoType("PROMOTION_CRAZED"),False)
 
 
 


### PR DESCRIPTION
## Summary
Fixes #435.

The Civilopedia/help text for the Ram of Vir reads:

> [ICON_BULLET]Units who Kill a Ram of Vir get fully healed.

(see `Assets/XML/Text/CIV4GameText_RevealBonus.xml`, tag `TXT_KEY_UNIT_RAM_OF_VIR_HELP`)

But the `PythonPostCombatLost` hook on `UNIT_RAM_OF_VIR` — `postCombatLostRamVir` in `Assets/python/entrypoints/CvSpellInterface.py` — only clears a list of negative-status promotions (Crazed, Diseased, Enervated, Fatigued, Plagued, Poisoned, Shattered Nerve, Unwholesome Addiction, Wintered, Withered).  It never resets the opponent's damage, so the killing unit keeps whatever wounds it took during the fight.

This PR adds the missing `pOpponent.setDamage(0, -1)` so behaviour matches the help text.

Also removes a harmless duplicate — `PROMOTION_CRAZED` was being cleared twice in the same block (once as the first promotion and again as the last).

## Test plan
- [ ] Spawn / encounter a Ram of Vir.
- [ ] Defend or attack with a damaged unit.
- [ ] On winning the fight, confirm the killer is at full HP.
- [ ] Confirm any of the listed negative-status promotions on the killer (e.g. Diseased) is still removed by the same hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)