### PR TITLE
Update Ram of Vir help text to mention status-effect cleanse (#435)

### DIFF
--- a/Assets/XML/Text/CIV4GameText_RevealBonus.xml
+++ b/Assets/XML/Text/CIV4GameText_RevealBonus.xml
@@ -11241,11 +11241,11 @@ A band of different colored hairs, moldy cloth, and dried blood tied together wi
 	
 	<TEXT>
 		<Tag>TXT_KEY_UNIT_RAM_OF_VIR_HELP</Tag>
-		<English>[ICON_BULLET]Units who Kill a Ram of Vir get fully healed.</English>
-		<French>[ICON_BULLET]Units who Kill a Ram of Vir get fully healed.</French>
-		<German>[ICON_BULLET]Units who Kill a Ram of Vir get fully healed.</German>
-		<Italian>[ICON_BULLET]Units who Kill a Ram of Vir get fully healed.</Italian>
-		<Spanish>[ICON_BULLET]Units who Kill a Ram of Vir get fully healed.</Spanish>
+		<English>[ICON_BULLET]Units who Kill a Ram of Vir get fully healed and their negative effects are cleared.</English>
+		<French>[ICON_BULLET]Units who Kill a Ram of Vir get fully healed and their negative effects are cleared.</French>
+		<German>[ICON_BULLET]Units who Kill a Ram of Vir get fully healed and their negative effects are cleared.</German>
+		<Italian>[ICON_BULLET]Units who Kill a Ram of Vir get fully healed and their negative effects are cleared.</Italian>
+		<Spanish>[ICON_BULLET]Units who Kill a Ram of Vir get fully healed and their negative effects are cleared.</Spanish>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_REQUIRES_NO_RELIGION</Tag>


### PR DESCRIPTION
## Summary
Related to #435.

The `TXT_KEY_UNIT_RAM_OF_VIR_HELP` tooltip currently advertises only the full heal granted to the killer:

> [ICON_BULLET]Units who Kill a Ram of Vir get fully healed.

In practice the `postCombatLostRamVir` hook in `Assets/python/entrypoints/CvSpellInterface.py` also clears every negative-status promotion on the winner (Crazed, Diseased, Enervated, Fatigued, Plagued, Poisoned, Shattered Nerve, Unwholesome Addiction, Wintered, Withered).  This PR updates the tooltip in all five language slots to describe both effects:

> [ICON_BULLET]Units who Kill a Ram of Vir get fully healed and their negative effects are cleared.

(Translations are unchanged — the existing entries are English mirrors, matching the rest of this file.)

## Relationship to #448
This is the **text** half of the fix.  #448 is the **code** half (adds the missing `setDamage(0, -1)` so the "fully healed" promise actually fires).  Either PR can land first; together they make the documented behaviour true and accurately documented.

## Test plan
- [ ] Open the Civilopedia or hover-tooltip for the Ram of Vir.
- [ ] Confirm the new sentence is shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)