### PR TITLE
Fix render staleness after reassignPlayerAdvanced (#433)

### DIFF
--- a/NoCrash DLL SourceCode/CvInitCore.cpp
+++ b/NoCrash DLL SourceCode/CvInitCore.cpp
@@ -536,6 +536,83 @@ void CvInitCore::reassignPlayerAdvanced(PlayerTypes eOldID, PlayerTypes eNewID, 
 			GET_PLAYER(eNewID).changeTempPlayerTimer(iTimer);
 			GET_PLAYER(eNewID).setRealPlayer(eOldID);
 		}
+
+		// Bugfix (#433): CvGame::setActivePlayer (called above for the
+		// player switch) dirties CultureBorders and re-emits per-plot
+		// fog/visibility/minimap-color, but two things are still wrong
+		// after reassignPlayerAdvanced returns:
+		//
+		//   (1) The engine's render-binding cache keeps showing the OLD
+		//       player's view (fog texture, cultural borders, minimap
+		//       colors) until something nukes it.  Comparing against
+		//       the military advisor screen — which reads CvPlot data
+		//       directly per-team and always renders correctly — the
+		//       gameplay state is fine; only the cache is stale.
+		//       RebuildAllPlots() is the only DLL-reachable call that
+		//       fully invalidates that cache.
+		//
+		//   (2) RebuildAllPlots() in turn clobbers the per-plot fog
+		//       texture state that the earlier setActivePlayer chain
+		//       set up, so we have to re-emit updateFog/updateVisibility/
+		//       updateMinimapColor *after* RebuildAllPlots — with the new
+		//       active player fully consistent — for the new view to be
+		//       drawn correctly.
+		//
+		//   (3) The existing clearSelectionList() call inside
+		//       CvGame::setActivePlayer isn't enough to actually clear
+		//       the selected unit / re-bind the camera.  Without an
+		//       explicit lookAt() to the new active player's capital,
+		//       the camera stays parked wherever the old player was
+		//       looking — and the old player's "explored area" bounds
+		//       prevent the user from scrolling to their actual units.
+		//
+		// Net effect: the original symptom reported as "Impersonate
+		// Leader (Gibbon Goetia / Aphelion Amulet) never returns control
+		// to my civ" — investigated via hapdbg + WinDbg on 2026-05-28 —
+		// turned out to be control returning correctly but the renderer
+		// stuck on the previous player's view (cultural borders gone,
+		// fog over the player's own cities, camera frozen).  This block
+		// makes the visible state match the gameplay state on both the
+		// forward swap (Khazad -> Bannor) and the back swap (Bannor ->
+		// Khazad, fired from CvPlayer::doTurn when the timer hits 0).
+		if (GC.IsGraphicsInitialized())
+		{
+			gDLL->getEngineIFace()->RebuildAllPlots();
+
+			GC.getMapINLINE().updateFog();
+			GC.getMapINLINE().updateVisibility();
+			GC.getMapINLINE().updateMinimapColor();
+
+			gDLL->getEngineIFace()->SetDirty(CultureBorders_DIRTY_BIT, true);
+			gDLL->getEngineIFace()->SetDirty(MinimapTexture_DIRTY_BIT, true);
+
+			PlayerTypes eActive = GC.getInitCore().getActivePlayer();
+			if (eActive != NO_PLAYER && GET_PLAYER(eActive).isAlive())
+			{
+				gDLL->getInterfaceIFace()->clearSelectionList();
+				gDLL->getInterfaceIFace()->clearSelectedCities();
+
+				CvCity* pCapital = GET_PLAYER(eActive).getCapitalCity();
+				CvPlot* pLookPlot = NULL;
+				if (pCapital != NULL)
+				{
+					pLookPlot = pCapital->plot();
+				}
+				else
+				{
+					int iLoop = 0;
+					CvUnit* pFirstUnit = GET_PLAYER(eActive).firstUnit(&iLoop, false);
+					if (pFirstUnit != NULL)
+					{
+						pLookPlot = pFirstUnit->plot();
+					}
+				}
+				if (pLookPlot != NULL)
+				{
+					gDLL->getInterfaceIFace()->lookAt(pLookPlot->getPoint(), CAMERALOOKAT_NORMAL);
+				}
+			}
+		}
 	}
 }
 //FfH: End Add


### PR DESCRIPTION
## Summary

Fixes #433.

The issue is titled "Gibbon civ switch bug" with a description that control never returns to your own civ after Impersonate Leader (Gibbon Goetia / Aphelion Amulet).  Live-investigated via hapdbg + WinDbg on a running AoE session 2026-05-28: **control does return correctly** — `CvPlayer::doTurn` decrements `m_iTempPlayerTimer` each round and fires the back-swap via `reassignPlayerAdvanced(getID(), getRealPlayer(), -1)` when it hits zero.

The actual bug is that the engine's **render-binding cache keeps showing the previous player's view** after `reassignPlayerAdvanced` returns.  The user thinks control hasn't returned because they're looking at their own civ through the wrong player's fog-of-war, with no cultural borders, and a camera locked into the other player's explored area.

## How we know it's a render-cache issue (not gameplay state)

Probed the engine's data via hapdbg right after a swap:

```
active=5 team=5
capital Torrolerial at (51,14)
  plot.getOwner = 5
  isRevealed(team=5) = 1
  isVisible(team=5)  = 1
```

Engine data: Bannor sees their own capital, plot is owned by Bannor.  Rendered output: capital is under fog of war and Bannor's borders don't render.

The **military advisor screen** (`F3`) reads `CvPlot` data directly per-team and consistently renders correctly during the bug.  Opening it also seems to coincidentally clear the render-cache staleness — that's what tipped us off.

## The fix

Adds a block at the end of `CvInitCore::reassignPlayerAdvanced`, gated on `GC.IsGraphicsInitialized()`, that:

1. `gDLL->getEngineIFace()->RebuildAllPlots()` — the only DLL-reachable call that fully invalidates the per-active-player render cache.
2. `GC.getMapINLINE().updateFog() / updateVisibility() / updateMinimapColor()` — re-emit per-plot fog texture state *after* `RebuildAllPlots`, which clobbers what `CvGame::setActivePlayer` set up earlier in the chain.
3. `gDLL->getEngineIFace()->SetDirty(CultureBorders_DIRTY_BIT | MinimapTexture_DIRTY_BIT, true)` — re-set engine-side dirty bits.
4. `gDLL->getInterfaceIFace()->clearSelectionList() / clearSelectedCities()` — the calls inside `CvGame::setActivePlayer` aren't sufficient on this code path.
5. `gDLL->getInterfaceIFace()->lookAt(activePlayer.getCapitalCity()->plot()->getPoint(), CAMERALOOKAT_NORMAL)` — reset camera to a useful location.  Without this the camera stays parked wherever the previous player was looking, and the engine's camera bounds prevent the user from scrolling out (they're bounded to the previous-active-player's explored area).  Falls back to the active player's first unit if they have no capital.

Order matters — calling \`updateFog\` etc. *before* \`RebuildAllPlots\` doesn't work (\`RebuildAllPlots\` wipes the per-plot fog texture), and calling \`RebuildAllPlots\` alone doesn't work (we have to re-emit fog after).

## Iteration log

Five DLL revisions were tested live before landing on this combination:

| Version | Change | Result |
|---|---|---|
| v1 | \`setFogOfWarFromStack()\` alone | borders still gone |
| v2 | \`PushFogOfWar(OFF) + Pop + setFogOfWarFromStack\` (replicating toggleDebugMode's fog-stack pump) | borders still gone |
| v3 | \`RebuildAllPlots()\` only | borders rendered but Bannor's own city under fog, camera frozen |
| v4 | + \`clearSelectionList\` + \`lookAt\` | camera fixed in a save where both teams have explored shared territory; fog still wrong |
| **v5** | **+ \`updateFog/updateVisibility/updateMinimapColor\` AFTER RebuildAllPlots** | **forward and back swap both clean** |

## Both swaps tested

- **Forward swap** (\`Khazad -> Bannor\` on spell cast): user immediately sees Bannor's view with their own borders, fog, units, and camera at Bannor's capital.
- **Back swap** (\`Bannor -> Khazad\` on timer expiry via \`CvPlayer::doTurn\`): user lands at Khazad's capital with Khazad's view rendered correctly from the first frame.

## Reproducing without a Gibbon

The render-cache issue is in \`reassignPlayerAdvanced\` itself, not the Impersonate Leader spell wrapper.  Easiest repro is to call \`CyGame().reassignPlayerAdvanced(humanSlot, anyAISlot, 3)\` from Python — same bug, same fix.  This also covers any *other* mechanic that calls \`reassignPlayerAdvanced\` (Pendulum, rank-balancing in challenge modes, scenario reassignments).

## Test plan

- [ ] Spawn a Gibbon Goetia hero on a unit cheat or via worldbuilder.
- [ ] Move it into an enemy AI civ's city.
- [ ] Cast Impersonate Leader.  Confirm camera + view + borders look right for the impersonated civ.
- [ ] Play 5+ turns as them.
- [ ] When the timer expires, confirm you land back at your own capital with your own civ fully rendered (borders, fog, units, minimap, camera).
- [ ] Repeat with Aphelion Amulet variant (\`SPELL_IMPERSONATE_LEADER_APHELION\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)