### PR TITLE
Skip Orphaned Goblin event when the victorious unit also died

### DIFF
--- a/Assets/Modules/NormalModules/MoreEvents/python/spellMoreEvents.py
+++ b/Assets/Modules/NormalModules/MoreEvents/python/spellMoreEvents.py
@@ -534,6 +534,14 @@ def spellReviewTreasureHuntClue(pCaster):
 # Orphaned Gobs
 def postCombatLossOrphanedGoblin(pCaster, pOpponent):
 	git			= gc.getInfoTypeForString
+	# If our winning unit (pOpponent) died in the same combat (mutual kill,
+	# death-blow, etc.) there is no surviving unit to receive the orphaned-
+	# goblin choice, so the event would fire and then throw when the choice is
+	# applied to a missing unit.  isDead() (damage >= maxHitPoints, already set
+	# by combat resolution) is the correct "was killed" test here -- NOT
+	# isAlive(), which only distinguishes a living unit from undead/demons.
+	if pOpponent.isDead():
+		return
 	iPlayer		= pOpponent.getOwner()
 	pPlayer		= gc.getPlayer(iPlayer)
 	iLostPlayer	= pCaster.getOwner()


### PR DESCRIPTION
## Problem

`postCombatLossOrphanedGoblin` lets the **winning** unit take a choice (crazed, become a goblin, spawn a goblin, or lose XP) after it kills a goblin-race barbarian. If that winning unit **also died in the same combat** (mutual kill, death-blow, etc.), the event still fired and then raised a Python exception — there was no surviving unit to apply the choice to.

## Fix

Guard the event with `pOpponent.isDead()` and return early:

```python
if pOpponent.isDead():
    return
```

`CvUnit::isDead()` is `getDamageReal() >= maxHitPoints()`, which is already true at the `postCombatLost` dispatch when the unit died in the combat — so the whole event is skipped at the source (covers both the AI and human-popup paths).

## Note (addressing review)

The earlier version of this PR used `isAlive()` — that was wrong, as the maintainer pointed out: `isAlive()` (`m_iAlive == 0`) separates **living** units from **undead/demons**, not "was killed", and would have wrongly skipped the event for every undead/demon victor (including the DTESH undead-slave outcome in this very function). Replaced with `isDead()`, the correct "was the unit killed" test.
