### PR TITLE
Fix AI_bestTech heap corruption on classless tech-reveal bonus (BONUS_ASH)

### DIFF
--- a/NoCrash DLL SourceCode/CvPlayerAI.cpp
+++ b/NoCrash DLL SourceCode/CvPlayerAI.cpp
@@ -4759,7 +4759,13 @@ TechTypes CvPlayerAI::AI_bestTech(int iMaxPathLength, bool bIgnoreCost, bool bAs
 	{
 		TechTypes eRevealTech = (TechTypes)GC.getBonusInfo((BonusTypes)iI).getTechReveal();
 		BonusClassTypes eBonusClass = (BonusClassTypes)GC.getBonusInfo((BonusTypes)iI).getBonusClassType();
-		if (eRevealTech != NO_TECH)
+		// eBonusClass can be NO_BONUSCLASS (-1) for a bonus whose BonusClassType
+		// is NONE but that still has a TechReveal (e.g. BONUS_ASH / TECH_DARK_SECRETS).
+		// The original paiBonusClass*[eBonusClass]++ then writes before the heap
+		// block and smashes the adjacent allocation header -> intermittent heap
+		// corruption that surfaces later (e.g. exit-to-menu teardown). Require a
+		// valid class index.
+		if (eRevealTech != NO_TECH && eBonusClass >= 0 && eBonusClass < GC.getNumBonusClassInfos())
 		{
 			if ((kTeam.isHasTech(eRevealTech)))
 			{
@@ -5209,7 +5215,8 @@ TechTypes CvPlayerAI::AI_bestTech(int iMaxPathLength, bool bIgnoreCost, bool bAs
 										iRevealValue += (AI_bonusVal((BonusTypes)iJ) * 50);
 
 										BonusClassTypes eBonusClass = (BonusClassTypes)GC.getBonusInfo((BonusTypes)iJ).getBonusClassType();
-										int iBonusClassTotal = (paiBonusClassRevealed[eBonusClass] + paiBonusClassUnrevealed[eBonusClass]);
+										// guard NO_BONUSCLASS (-1) / out-of-range index (see AI_bestTech write loop above)
+										int iBonusClassTotal = (eBonusClass >= 0 && eBonusClass < GC.getNumBonusClassInfos()) ? (paiBonusClassRevealed[eBonusClass] + paiBonusClassUnrevealed[eBonusClass]) : 0;
 
 										//iMultiplier is basically a desperation value
 										//it gets larger as the AI runs out of options
@@ -6488,7 +6495,13 @@ TechTypes CvPlayerAI::AI_bestTech(int iMaxPathLength, bool bIgnoreCost, bool bAs
 	{
 		TechTypes eRevealTech = (TechTypes)GC.getBonusInfo((BonusTypes)iI).getTechReveal();
 		BonusClassTypes eBonusClass = (BonusClassTypes)GC.getBonusInfo((BonusTypes)iI).getBonusClassType();
-		if (eRevealTech != NO_TECH)
+		// eBonusClass can be NO_BONUSCLASS (-1) for a bonus whose BonusClassType
+		// is NONE but that still has a TechReveal (e.g. BONUS_ASH / TECH_DARK_SECRETS).
+		// The original paiBonusClass*[eBonusClass]++ then writes before the heap
+		// block and smashes the adjacent allocation header -> intermittent heap
+		// corruption that surfaces later (e.g. exit-to-menu teardown). Require a
+		// valid class index.
+		if (eRevealTech != NO_TECH && eBonusClass >= 0 && eBonusClass < GC.getNumBonusClassInfos())
 		{
 			if ((kTeam.isHasTech(eRevealTech)))
 			{
@@ -7027,7 +7040,8 @@ TechTypes CvPlayerAI::AI_bestTech(int iMaxPathLength, bool bIgnoreCost, bool bAs
 								iRevealValue += (AI_bonusVal((BonusTypes)iJ) * 50);
 
 								BonusClassTypes eBonusClass = (BonusClassTypes)GC.getBonusInfo((BonusTypes)iJ).getBonusClassType();
-								int iBonusClassTotal = (paiBonusClassRevealed[eBonusClass] + paiBonusClassUnrevealed[eBonusClass]);
+								// guard NO_BONUSCLASS (-1) / out-of-range index (see AI_bestTech write loop above)
+								int iBonusClassTotal = (eBonusClass >= 0 && eBonusClass < GC.getNumBonusClassInfos()) ? (paiBonusClassRevealed[eBonusClass] + paiBonusClassUnrevealed[eBonusClass]) : 0;
 
 								//iMultiplier is basically a desperation value
 								//it gets larger as the AI runs out of options


### PR DESCRIPTION
### Problem

`CvPlayerAI::AI_bestTech` (both overloads) builds three scratch arrays sized by `GC.getNumBonusClassInfos()`:

```cpp
paiBonusClassRevealed   = new int[GC.getNumBonusClassInfos()];
paiBonusClassUnrevealed = new int[GC.getNumBonusClassInfos()];
paiBonusClassHave       = new int[GC.getNumBonusClassInfos()];
```

and fills them indexed by each bonus's class, guarded only by the tech reveal:

```cpp
BonusClassTypes eBonusClass = GC.getBonusInfo(iI).getBonusClassType();
if (eRevealTech != NO_TECH)            // index is never validated
{
    paiBonusClassRevealed[eBonusClass]++;
    ...
}
```

`getBonusClassType()` returns `NO_BONUSCLASS` (= **-1**) for any bonus whose `<BonusClassType>` is `NONE`. Combined with a `<TechReveal>`, the code does `paiBonusClass*[-1]++`, writing **before** the heap block and smashing the adjacent allocation header.

This is **intermittent heap corruption** — the stray write lands on whatever block precedes the array, so it only bites sometimes and usually surfaces *later*. We hit it as an exit-to-main-menu teardown crash; a Windows heap with corruption detection enabled reports the failure inside `free()` on the `AI_bestTech` call stack.

### Trigger in data

`CIV4BonusInfos.xml` has exactly one bonus with a TechReveal but no class:

| Bonus | `<BonusClassType>` | `<TechReveal>` |
|-------|--------------------|----------------|
| `BONUS_ASH` | `NONE` | `TECH_DARK_SECRETS` |

`NONE` is a legal value for that field, so this is a **code** bug — the AI must not assume every tech-revealing bonus has a valid class.

### Fix

Bounds-check `eBonusClass` in both `AI_bestTech` overloads — the write loops and the symmetric read loops that compute the reveal-scarcity multiplier:

```cpp
if (eRevealTech != NO_TECH && eBonusClass >= 0 && eBonusClass < GC.getNumBonusClassInfos())
```
```cpp
int iBonusClassTotal = (eBonusClass >= 0 && eBonusClass < GC.getNumBonusClassInfos())
                     ? (paiBonusClassRevealed[eBonusClass] + paiBonusClassUnrevealed[eBonusClass]) : 0;
```

A classless bonus contributes no bonus-class-scarcity multiplier to its reveal value, which is the correct degraded behavior. No XML change required.