### PR TITLE
Fix promotion replacedBy iteration for terminal promotion chains (PHOENIX)

### DIFF
--- a/NoCrash DLL SourceCode/CvUnit.cpp
+++ b/NoCrash DLL SourceCode/CvUnit.cpp
@@ -22375,7 +22375,15 @@ void CvUnit::setHasPromotion(PromotionTypes eIndex, bool bNewValue, bool bSupres
 				{
 					if (GC.getPromotionInfo((PromotionTypes)iI).getNumPromotionReplacedBy() > 0)
 					{
-						for (int iJ = 0; iJ < kPromotion.getNumPromotionReplacedBy(); iJ++)
+						// Bugfix: iterate the EXISTING promotion's replacedBy list,
+						// not the new promotion's.  We're checking "does anything in
+						// iI's replacedBy list equal the promotion we're now adding?".
+						// Indexing iI's list while bounding by kPromotion's count
+						// silently no-ops whenever kPromotion has fewer entries (or
+						// none) than iI -- which is exactly when terminal chains
+						// like PHOENIX_EGG_HELD -> PHOENIX_SMALL fail to remove the
+						// old promotion.
+						for (int iJ = 0; iJ < GC.getPromotionInfo((PromotionTypes)iI).getNumPromotionReplacedBy(); iJ++)
 						{
 							if (GC.getPromotionInfo((PromotionTypes)iI).getPromotionReplacedBy(iJ) == eIndex)
 							{


### PR DESCRIPTION
### Problem

When a unit gains a promotion, `CvUnit` strips any promotions the new one replaces. That loop iterates the **existing** promotion's `replacedBy` list but bounds it by the **new** promotion's count:

```cpp
for (int iJ = 0; iJ < kPromotion.getNumPromotionReplacedBy(); iJ++)   // kPromotion = the NEW promotion
    ... GC.getPromotionInfo((PromotionTypes)iI).getPromotionReplacedBy(iJ) ...   // iI = the EXISTING promotion
```

Whenever the existing promotion (`iI`) has *more* `replacedBy` entries than the new one (`kPromotion`) — or the new one has none — the loop runs too few iterations (or zero), so the old promotion is never removed. That's exactly what breaks terminal chains like `PHOENIX_EGG_HELD` → `PHOENIX_SMALL`.

### Fix

Bound the loop by the existing promotion's own `replacedBy` count:

```cpp
for (int iJ = 0; iJ < GC.getPromotionInfo((PromotionTypes)iI).getNumPromotionReplacedBy(); iJ++)
```