### PR TITLE
Fix IndexError in ErebusContinent addSuburbsRoads

### DIFF
--- a/PrivateMaps/ErebusContinent.py
+++ b/PrivateMaps/ErebusContinent.py
@@ -4482,7 +4482,7 @@ def addSuburbsRoads (cx, cy, rxs, rys):
 	for n in range(numcands):
 		if len(candx) == 0: break
 		posn = game.getMapRandNum(len(candx), "")
-		x = candx[n] ; y = candy[n]
+		x = candx[posn] ; y = candy[posn]
 		addSuburbRoad(cx, cy, x, y, ra)
 		del candx[posn] ; del candy[posn]
 


### PR DESCRIPTION
## Problem

Starting a new game on the **Erebus Continent** map script with the ruins map option enabled can crash during map generation:

```
File "ErebusContinent", line 4206, in normalizeAddExtras
File "ErebusContinent", line 4498, in addSuburbsRoads
IndexError: list index out of range
```

## Cause

In `addSuburbsRoads`, the candidate loop picks a random slot `posn`, **deletes** `candx[posn]`/`candy[posn]` each pass, but **reads** `candx[n]`/`candy[n]` using the loop counter:

```python
for n in range(numcands):
    if len(candx) == 0: break
    posn = game.getMapRandNum(len(candx), "")
    x = candx[n] ; y = candy[n]          # BUG: indexed by n, not posn
    addSuburbRoad(cx, cy, x, y, ra)
    del candx[posn] ; del candy[posn]
```

As elements are deleted the list shrinks, so `candx[n]` walks off the end. The `if len(candx) == 0` guard only catches the fully-empty case, not `n >= len(candx)`. Example: 2 candidates + `numcands >= 2` -> on `n=1` the list has length 1 and `candx[1]` raises `IndexError`.

## Fix

Index by `posn` for the read as well. `posn` is `getMapRandNum(len(candx))`, always in `[0, len-1]`, and matches the `del candx[posn]` that follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)