### PR TITLE
Prevent infinite hang on flow-map cycles in ErebusContinent rainfall

### DIFF
--- a/PrivateMaps/ErebusContinent.py
+++ b/PrivateMaps/ErebusContinent.py
@@ -3559,6 +3559,12 @@ class RiverMap :
 		#Now use the flowMap as a guide to distribute average rainfall.
 		#Wherever the most rainfall ends up is where the rivers will be.
 		print "Distributing rainfall"
+		# Bugfix: flow map can contain cycles on some seeds (siltifyLakes /
+		# createLakeDepressions modify heightmap but don't guarantee the
+		# flow map stays a DAG).  Without a step cap the while-loop below
+		# hangs the engine forever during "Distributing rainfall".
+		_rainfall_step_cap = mc.height * mc.width
+		_rainfall_cycle_hits = 0
 		for y in range(mc.height):
 			for x in range(mc.width):
 				i = GetIndex(x,y)
@@ -3566,7 +3572,12 @@ class RiverMap :
 				rainFall = self.averageRainfallMap[i]
 				xx = x
 				yy = y
+				_steps = 0
 				while(flow != self.L and flow != self.O):
+					_steps += 1
+					if _steps > _rainfall_step_cap:
+						_rainfall_cycle_hits += 1
+						break
 					if(flow == self.N):
 						yy += 1
 					elif(flow == self.S):
@@ -3590,6 +3601,8 @@ class RiverMap :
 					#reset flow
 					flow = self.flowMap[ii]
 
+		if _rainfall_cycle_hits > 0:
+			print "  WARN: flow-map cycles detected on %d origin tiles" % _rainfall_cycle_hits
 		riverThreshold = sm.plainsThreshold * mc.RiverThreshold
 		for i in range(mc.height*mc.width):
 			if(self.drainageMap[i] > riverThreshold):


### PR DESCRIPTION
## Problem

On some map seeds, generating an **Erebus Continent** map hangs forever at:

```
Distributing rainfall
```

Map generation never completes and the engine has to be killed.

## Cause

`RiverMap`'s rainfall distribution walks `flowMap` from each origin tile until it reaches a lake (`self.L`) or ocean (`self.O`):

```python
while(flow != self.L and flow != self.O):
    ... step xx/yy along flow ...
    flow = self.flowMap[ii]
```

This assumes the flow map is acyclic. It isn't always — `siltifyLakes` / `createLakeDepressions` mutate the heightmap after the flow map is built without guaranteeing it stays a DAG. When the walk enters a cycle, the loop never terminates.

## Fix

Cap each walk at `height * width` steps (a safe upper bound on any cycle-free path through the grid) and break out if exceeded. Count how many origin tiles hit the cap and print a single `WARN` afterward, so a genuinely degenerate flow map is diagnosable instead of silently hanging.

This only changes behavior on the pathological (currently infinite-loop) case; normal seeds terminate well under the cap and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)