### PR TITLE
Fix NO_SPECIALIST crashes for bUnique specialist classes (founding + help/GPP)

### DIFF
--- a/NoCrash DLL SourceCode/CvCity.cpp
+++ b/NoCrash DLL SourceCode/CvCity.cpp
@@ -1196,20 +1196,22 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 		m_paaiLocalSpecialistYield = new int*[GC.getNumSpecialistClassInfos()];
 		for (int iI = 0; iI < GC.getNumSpecialistClassInfos(); iI++)
 		{
+			SpecialistTypes eSpecialist = getSpecialistTypeFromClass((SpecialistClassTypes)iI);
 			m_paaiLocalSpecialistYield[iI] = new int[NUM_YIELD_TYPES];
 			for (int iJ = 0; iJ < NUM_YIELD_TYPES; iJ++)
 			{
-				m_paaiLocalSpecialistYield[iI][iJ] = GET_PLAYER(getOwner()).getSpecialistTypeExtraYield((SpecialistTypes)getSpecialistTypeFromClass((SpecialistClassTypes)iI), (YieldTypes)iJ);
+				m_paaiLocalSpecialistYield[iI][iJ] = (eSpecialist == NO_SPECIALIST) ? 0 : GET_PLAYER(getOwner()).getSpecialistTypeExtraYield(eSpecialist, (YieldTypes)iJ);
 			}
 		}
 		FAssertMsg(m_paaiLocalSpecialistCommerce==NULL, "About to leak memory, CvCity::m_paaiLocalSpecialistCommerce is NULL");
 		m_paaiLocalSpecialistCommerce = new int*[GC.getNumSpecialistClassInfos()];
 		for (int iI = 0; iI < GC.getNumSpecialistClassInfos(); iI++)
 		{
+			SpecialistTypes eSpecialist = getSpecialistTypeFromClass((SpecialistClassTypes)iI);
 			m_paaiLocalSpecialistCommerce[iI] = new int[NUM_COMMERCE_TYPES];
 			for (int iJ = 0; iJ < NUM_COMMERCE_TYPES; iJ++)
 			{
-				m_paaiLocalSpecialistCommerce[iI][iJ] = GET_PLAYER(getOwner()).getSpecialistTypeExtraCommerce((SpecialistTypes)getSpecialistTypeFromClass((SpecialistClassTypes)iI), (CommerceTypes)iJ);
+				m_paaiLocalSpecialistCommerce[iI][iJ] = (eSpecialist == NO_SPECIALIST) ? 0 : GET_PLAYER(getOwner()).getSpecialistTypeExtraCommerce(eSpecialist, (CommerceTypes)iJ);
 			}
 		}
 		m_paiLocalSpecialistHappiness = new int[GC.getNumSpecialistClassInfos()];
@@ -1218,9 +1220,10 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 		m_paiLocalSpecialistGPP = new int[GC.getNumSpecialistClassInfos()];
 		for (int iI = 0; iI < GC.getNumSpecialistClassInfos(); iI++)
 		{
-			m_paiLocalSpecialistHappiness[iI] = GET_PLAYER(getOwner()).getSpecialistTypeExtraHappiness((SpecialistTypes)getSpecialistTypeFromClass((SpecialistClassTypes)iI));
-			m_paiLocalSpecialistHealth[iI] = GET_PLAYER(getOwner()).getSpecialistTypeExtraHealth((SpecialistTypes)getSpecialistTypeFromClass((SpecialistClassTypes)iI));
-			m_paiLocalSpecialistCrime[iI] = GET_PLAYER(getOwner()).getSpecialistTypeExtraCrime((SpecialistTypes)getSpecialistTypeFromClass((SpecialistClassTypes)iI));
+			SpecialistTypes eSpecialist = getSpecialistTypeFromClass((SpecialistClassTypes)iI);
+			m_paiLocalSpecialistHappiness[iI] = (eSpecialist == NO_SPECIALIST) ? 0 : GET_PLAYER(getOwner()).getSpecialistTypeExtraHappiness(eSpecialist);
+			m_paiLocalSpecialistHealth[iI] = (eSpecialist == NO_SPECIALIST) ? 0 : GET_PLAYER(getOwner()).getSpecialistTypeExtraHealth(eSpecialist);
+			m_paiLocalSpecialistCrime[iI] = (eSpecialist == NO_SPECIALIST) ? 0 : GET_PLAYER(getOwner()).getSpecialistTypeExtraCrime(eSpecialist);
 			m_paiLocalSpecialistGPP[iI] = 0;
 		}
 /*************************************************************************************************/

--- a/NoCrash DLL SourceCode/CvDLLWidgetData.cpp
+++ b/NoCrash DLL SourceCode/CvDLLWidgetData.cpp
@@ -3895,7 +3895,9 @@ void CvDLLWidgetData::parseChangeSpecialistHelp(CvWidgetDataStruct &widgetDataSt
 		}
 		else
 		{
-			szBuffer.assign(gDLL->getText("TXT_KEY_MISC_REMOVE_SPECIALIST", GC.getSpecialistInfo(pHeadSelectedCity->getSpecialistTypeFromClass((SpecialistClassTypes) widgetDataStruct.m_iData1)).getTextKeyWide()));
+			SpecialistTypes eSpecialist = pHeadSelectedCity->getSpecialistTypeFromClass((SpecialistClassTypes) widgetDataStruct.m_iData1);
+			if (eSpecialist != NO_SPECIALIST)
+				szBuffer.assign(gDLL->getText("TXT_KEY_MISC_REMOVE_SPECIALIST", GC.getSpecialistInfo(eSpecialist).getTextKeyWide()));
 
 			if (pHeadSelectedCity->getForceSpecialistClassCount((SpecialistClassTypes)(widgetDataStruct.m_iData1)) > 0)
 			{

--- a/NoCrash DLL SourceCode/CvGameTextMgr.cpp
+++ b/NoCrash DLL SourceCode/CvGameTextMgr.cpp
@@ -5888,6 +5888,9 @@ void CvGameTextMgr::setPlotHelp(CvWStringBuffer& szString, CvPlot* pPlot)
 					// can this city have any of this specialist?
 					if (iMaxThisSpecialist > 0 || bIsDefaultSpecialist)
 					{
+						SpecialistTypes eSpecialist = pCity->getSpecialistTypeFromClass((SpecialistClassTypes) iI);
+						if (eSpecialist == NO_SPECIALIST)
+							continue;
 						// start color
 						if (pCity->getForceSpecialistClassCount((SpecialistClassTypes) iI) > 0)
 							szString.append(CvWString::format(L"\n" SETCOLR, TEXT_COLOR("COLOR_NEGATIVE_TEXT")));
@@ -5897,7 +5900,7 @@ void CvGameTextMgr::setPlotHelp(CvWStringBuffer& szString, CvPlot* pPlot)
 							szString.append(CvWString::format(L"\n" SETCOLR, TEXT_COLOR("COLOR_HIGHLIGHT_TEXT")));
 
 						// add name
-						szString.append(GC.getSpecialistInfo(pCity->getSpecialistTypeFromClass((SpecialistClassTypes) iI)).getDescription());
+						szString.append(GC.getSpecialistInfo(eSpecialist).getDescription());
 
 						// end color
 						szString.append(CvWString::format( ENDCOLR ));
@@ -10683,7 +10686,7 @@ void CvGameTextMgr::parseSpecialistHelp(CvWStringBuffer &szHelpString, Specialis
 			if (bHasChanges)
 			{
 				szHelpString.append(szBuffer);
-				if (pCity != NULL)
+				if (pCity != NULL && pCity->getSpecialistTypeFromClass((SpecialistClassTypes)i) != NO_SPECIALIST)
 					szHelpString.append(gDLL->getText("TXT_KEY_FROM_SPECIALIST", GC.getSpecialistInfo(pCity->getSpecialistTypeFromClass((SpecialistClassTypes)i)).getTextKeyWide()));
 				else
 					szHelpString.append(gDLL->getText("TXT_KEY_FROM_SPECIALIST", GC.getSpecialistInfo((SpecialistTypes)GC.getSpecialistClassInfo((SpecialistClassTypes)i).getDefaultSpecialistIndex()).getTextKeyWide()));
@@ -10693,7 +10696,7 @@ void CvGameTextMgr::parseSpecialistHelp(CvWStringBuffer &szHelpString, Specialis
 			if (bHasChanges)
 			{
 				szHelpString.append(szBuffer);
-				if (pCity != NULL)
+				if (pCity != NULL && pCity->getSpecialistTypeFromClass((SpecialistClassTypes)i) != NO_SPECIALIST)
 					szHelpString.append(gDLL->getText("TXT_KEY_FROM_SPECIALIST", GC.getSpecialistInfo(pCity->getSpecialistTypeFromClass((SpecialistClassTypes)i)).getTextKeyWide()));
 				else
 					szHelpString.append(gDLL->getText("TXT_KEY_FROM_SPECIALIST", GC.getSpecialistInfo((SpecialistTypes)GC.getSpecialistClassInfo((SpecialistClassTypes)i).getDefaultSpecialistIndex()).getTextKeyWide()));
@@ -10706,7 +10709,7 @@ void CvGameTextMgr::parseSpecialistHelp(CvWStringBuffer &szHelpString, Specialis
 				if(iSpecialistClassCrime > 0)
 					szHelpString.append(L"+");
 				szHelpString.append(gDLL->getText(L"%d1[ICON_CRIME]", iSpecialistClassCrime));
-				if(pCity != NULL)
+				if(pCity != NULL && pCity->getSpecialistTypeFromClass((SpecialistClassTypes)i) != NO_SPECIALIST)
 					szHelpString.append(gDLL->getText("TXT_KEY_FROM_SPECIALIST", GC.getSpecialistInfo(pCity->getSpecialistTypeFromClass((SpecialistClassTypes)i)).getTextKeyWide()));
 				else
 					szHelpString.append(gDLL->getText("TXT_KEY_FROM_SPECIALIST", GC.getSpecialistInfo((SpecialistTypes)GC.getSpecialistClassInfo((SpecialistClassTypes)i).getDefaultSpecialistIndex()).getTextKeyWide()));
@@ -20241,15 +20244,21 @@ void CvGameTextMgr::setBuildingHelp(CvWStringBuffer &szBuffer, BuildingTypes eBu
 		//SpecialistTypes eSpecialist = (SpecialistTypes)GC.getSpecialistClassInfo((SpecialistClassTypes)iI).getDefaultSpecialistIndex();
 		if (pCity != NULL)
 		{
+			SpecialistTypes eSpecialist = pCity->getSpecialistTypeFromClass((SpecialistClassTypes)iI);
+			if (eSpecialist == NO_SPECIALIST)
+				continue;
 			szSpecialistNameBuffer[iI].append(L"[COLOR_UNIT_TEXT][LINK=literal]");
-			szSpecialistNameBuffer[iI] = gDLL->getText(GC.getSpecialistInfo(pCity->getSpecialistTypeFromClass((SpecialistClassTypes)iI)).getTextKeyWide());
+			szSpecialistNameBuffer[iI] = gDLL->getText(GC.getSpecialistInfo(eSpecialist).getTextKeyWide());
 			szSpecialistNameBuffer[iI].append(L"[\\LINK][COLOR_REVERT]");
 			bBufferEmpty[iI] = false;
 		}
 		else if (ePlayer != NO_PLAYER && vCivsBuilding[GET_PLAYER(ePlayer).getCivilizationType()])
 		{
+			SpecialistTypes eSpecialist = (SpecialistTypes)GC.getCivilizationInfo(GET_PLAYER(ePlayer).getCivilizationType()).getCivilizationSpecialists(iI);
+			if (eSpecialist == NO_SPECIALIST)
+				continue;
 			szSpecialistNameBuffer[iI].append(L"[COLOR_UNIT_TEXT][LINK=literal]");
-			szSpecialistNameBuffer[iI] = gDLL->getText(GC.getSpecialistInfo((SpecialistTypes)GC.getCivilizationInfo(GET_PLAYER(ePlayer).getCivilizationType()).getCivilizationSpecialists(iI)).getTextKeyWide());
+			szSpecialistNameBuffer[iI] = gDLL->getText(GC.getSpecialistInfo(eSpecialist).getTextKeyWide());
 			szSpecialistNameBuffer[iI].append(L"[\\LINK][COLOR_REVERT]");
 			bBufferEmpty[iI] = false;
 		}

--- a/NoCrash DLL SourceCode/CvPlayer.cpp
+++ b/NoCrash DLL SourceCode/CvPlayer.cpp
@@ -31358,7 +31358,8 @@ void CvPlayer::changeSpecialistClassExtraGPP(SpecialistClassTypes eIndex1, int i
 		//Updating current specialists in cities
 		for (pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
 		{
-			eGreatPeopleUnit = ((UnitTypes)(pLoopCity->getCityUnits(GC.getSpecialistInfo(pLoopCity->getSpecialistTypeFromClass((SpecialistClassTypes)eIndex1)).getGreatPeopleUnitClass())));
+			SpecialistTypes eSpecialist = pLoopCity->getSpecialistTypeFromClass((SpecialistClassTypes)eIndex1);
+			eGreatPeopleUnit = (eSpecialist == NO_SPECIALIST) ? NO_UNIT : ((UnitTypes)(pLoopCity->getCityUnits(GC.getSpecialistInfo(eSpecialist).getGreatPeopleUnitClass())));
 			if (eGreatPeopleUnit != NO_UNIT)
 			{
 				pLoopCity->changeGreatPeopleUnitRate(eGreatPeopleUnit, pLoopCity->getSpecialistClassCount(eIndex1) * iChange);


### PR DESCRIPTION
## Problem

`bUnique` specialist classes (e.g. `SPECIALISTCLASS_STATESMAN`) resolve to **`NO_SPECIALIST` (-1)** for any civ that doesn't explicitly grant them — `InitSpecialistDefaults` deliberately sets unique classes to -1. Several call sites pass that -1 straight into `GC.getSpecialistInfo(...)` (via `getSpecialistTypeFromClass(class)` or `getCivilizationSpecialists(class)`), which returns a garbage pointer; the next dereference (`getTextKeyWide` / `getDescription` / `getGreatPeopleUnitClass` / the per-yield arrays) then access-violates.

Two were reproduced under WinDbg:

**1. City founding** (`CvUnit::found` → `CvPlayer::initCity` → `CvCity::init` → `CvCity::reset`):
```
CvPlayer::getSpecialistTypeExtraYield+0x12   ; m_ppaiSpecialistTypeExtraYield[-1]
```
**2. Building hover/construct help** (`CvDLLWidgetData::parseHelp` → `parseConstructHelp` → `CvGameTextMgr::setBuildingHelp` → `CvInfoBase::getTextKeyWide`):
```
mov dword ptr [ecx+58h] ... ds:...=????????   ; getSpecialistInfo(-1).getTextKeyWide()
```

Every other specialist-class loop in the code already guards this (e.g. `CvCity::updateSpecialistHealth`, `CvCity.cpp:19551`) — these sites were simply missing the guard. Latent until a `bUnique` specialist class was added.

## Fix

Guard `NO_SPECIALIST` before indexing, matching the existing convention. `getDefaultSpecialistIndex()` stays valid even for unique classes, so the help-text `else` branches that use it are safe — `NO_SPECIALIST` is routed there.

| File | Site |
|---|---|
| `CvCity.cpp` | `reset` — local-specialist yield/commerce/happiness/health/crime init |
| `CvGameTextMgr.cpp` | `setBuildingHelp` (both branches), city-screen specialist list, `parseSpecialistHelp` yield/commerce/crime |
| `CvPlayer.cpp` | `changeSpecialistClassExtraGPP` |
| `CvDLLWidgetData.cpp` | `parseChangeSpecialistHelp` |

No data/XML change needed — the -1 is correct, intentional data. City founding verified crash-free with this build; the other sites are static guards on the same pattern.
