### PR TITLE
Fix specialist espionage corruption from tech acquisition (CvTeam::processTech)

### DIFF
--- a/NoCrash DLL SourceCode/CvTeam.cpp
+++ b/NoCrash DLL SourceCode/CvTeam.cpp
@@ -6679,7 +6679,7 @@ void CvTeam::processTech(TechTypes eTech, int iChange)
 				}
 				for (int iK = 0; iK < NUM_COMMERCE_TYPES; iK++)
 				{
-					GET_PLAYER((PlayerTypes)iI).changeSpecialistTypeExtraCommerce((SpecialistTypes)iJ, (CommerceTypes)iK, GC.getTechInfo(eTech).getSpecialistTypeYieldChange(iJ, iK) * iChange);
+					GET_PLAYER((PlayerTypes)iI).changeSpecialistTypeExtraCommerce((SpecialistTypes)iJ, (CommerceTypes)iK, GC.getTechInfo(eTech).getSpecialistTypeCommerceChange(iJ, iK) * iChange);
 				}
 			}
 


### PR DESCRIPTION
## Symptom

Specialists (and the Great-Person **JOIN CITY** preview) display garbage **espionage** values — 10-digit positive/negative numbers — in cities. The other three commerce types (gold/research/culture) are fine; only espionage is affected. With employed specialists, it also corrupts the city's actual espionage output (the value is multiplied by specialist count in `getBaseCommerceRateTimes100`).

## Root cause

`CvTeam::processTech` (`NoCrash DLL SourceCode/CvTeam.cpp`) applies per-tech specialist bonuses. The commerce loop is a copy-paste of the yield loop directly above it and was never switched to a commerce source:

```cpp
for (int iK = 0; iK < NUM_YIELD_TYPES; iK++)        // 0..2  (correct)
    ...changeSpecialistTypeExtraYield(... getSpecialistTypeYieldChange(iJ, iK) ...);

for (int iK = 0; iK < NUM_COMMERCE_TYPES; iK++)      // 0..3  (bug)
    ...changeSpecialistTypeExtraCommerce(... getSpecialistTypeYieldChange(iJ, iK) ...);   // reads YIELD
```

Two defects on the commerce line:
1. It reads the **yield** array into the **commerce** destination.
2. The yield row is `NUM_YIELD_TYPES` (3) wide, but the loop runs to `NUM_COMMERCE_TYPES` (4), so `iK == COMMERCE_ESPIONAGE (3)` reads **one past** the yield row.

The out-of-bounds value is written into `m_ppaiSpecialistTypeExtraCommerce[*][ESPIONAGE]` for every specialist, on **every tech acquired** (including starting techs). It then propagates into each city's `m_paaiLocalSpecialistCommerce` (seeded from the player array at city construction). Because espionage is the commerce type BTS added on top of vanilla's three, it's exactly the column the off-by-one lands on.

Verified live in WinDbg: the player/city espionage columns held identical garbage across sessions, traced back to this loop; columns 0/1/2 were clean `0`.

## Fix

Read `getSpecialistTypeCommerceChange` — the `NUM_COMMERCE_TYPES`-wide array `CvTechInfo` already allocates, parses from XML (`SetCommerce`), and serializes — instead of `getSpecialistTypeYieldChange`. This corrects both the wrong source and the OOB read.

```diff
-    ...getTechInfo(eTech).getSpecialistTypeYieldChange(iJ, iK) * iChange);
+    ...getTechInfo(eTech).getSpecialistTypeCommerceChange(iJ, iK) * iChange);
```

One line; no behavior change for techs that grant no specialist commerce (the common case → 0). Note: existing saves created before this fix have the garbage baked into the persisted specialist-commerce arrays and need a one-time scrub of the espionage column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
