### PR TITLE
Fix two non-void CvUnit functions that fall off the end (canAirlift, getArtInfo)

### DIFF
--- a/NoCrash DLL SourceCode/CvUnit.cpp
+++ b/NoCrash DLL SourceCode/CvUnit.cpp
@@ -7006,6 +7006,12 @@ bool CvUnit::canAirlift(const CvPlot* pPlot) const
 			return false;
 		}
 	}
+
+	// Upstream bug: function fell off end without returning. VC7.1 cl.exe
+	// happened to emit "mov al, 1; ret" so retail worked by accident;
+	// clang/modern compilers treat fall-off as UB and return false on the
+	// success path, hiding the airlift button.
+	return true;
 }
 
 
@@ -32158,6 +32164,10 @@ const CvArtInfoUnit* CvUnit::getArtInfo(int i, EraTypes eEra) const
 
 		return ARTFILEMGR.getUnitArtInfo(getExtraArtDefineTag3());
 	}
+	// Same UB pattern as canAirlift: original cl.exe returned NULL via fall-off;
+	// clang's UB-aware optimizer may return garbage. Make NULL explicit so
+	// callers (which already null-check via the ART_INFO_DEFN fallback) work.
+	return NULL;
 }
 
 const TCHAR* CvUnit::getButton() const


### PR DESCRIPTION
## Symptom

A city with a **Flying Mounts Stable** (`BUILDING_GRIFFON_WEYR`, `iAirlift=1`) does not let units use the airlift/airdrop ability — the action icon never appears. Caught after rebuilding the DLL with clang.

## Root cause

Two `CvUnit` methods reach the end of a non-void function without a `return` on one path:

- **`canAirlift`** — after the city/plot airlift-capacity checks pass, the function just `}`-closes with no `return true`.
- **`getArtInfo`** — after the last `getGroupDefinitions()+2` branch, it `}`-closes with no `return NULL`.

Retail VC7.1 `cl.exe` happened to emit `mov al, 1; ret` (and a NULL-ish EAX) on those paths, so the shipped DLL worked **by accident**. clang treats fall-off of a non-void function as undefined behaviour and may return `false` / a garbage pointer — so `canAirlift` reports false on success (airlift button hidden) and `getArtInfo` can hand back a garbage `CvArtInfoUnit*`.

## Fix

Add the missing returns explicitly:

```diff
   // canAirlift, after the airlift-capacity checks
   }
+  return true;
 }
```
```diff
   // getArtInfo, after the last group-definition branch
   }
+  return NULL;   // callers already null-check via the ART_INFO_DEFN fallback
 }
```

Two one-line returns; no behavioural change under cl.exe, correct behaviour under clang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
