### PR TITLE
Fix uninitialized free of m_paiPeakYieldChange (heap corruption at XML load)

### DIFF
--- a/NoCrash DLL SourceCode/CvInfos.cpp
+++ b/NoCrash DLL SourceCode/CvInfos.cpp
@@ -27231,7 +27231,8 @@ m_pbMaintainFeatures(NULL)
 m_piFeatureHealthPercentChanges(NULL),
 m_ppiFeatureYieldChanges(NULL),
 m_ppiImprovementYieldChanges(NULL),
-m_ppiTerrainYieldChanges(NULL)
+m_ppiTerrainYieldChanges(NULL),
+m_paiPeakYieldChange(NULL)
 
 //ClimateSystem:
 ,m_iFormClimateZoneType(NO_CLIMATEZONE)


### PR DESCRIPTION
## Problem
`CvCivilizationInfo::m_paiPeakYieldChange` is read from XML, exposed via `getPeakYieldChange()`, and freed in `~CvCivilizationInfo` (`SAFE_DELETE_ARRAY`, CvInfos.cpp:27310) — but the **constructor init-list never initializes it to NULL**. Its four sibling "New Tag" arrays (`m_piFeatureHealthPercentChanges`, `m_ppiFeatureYieldChanges`, `m_ppiImprovementYieldChanges`, `m_ppiTerrainYieldChanges`) are all `(NULL)`-initialized; this one was missed.

For any `CvCivilizationInfo` whose XML doesn't populate the `PeakYieldChange` tag, the member holds indeterminate garbage, and the destructor runs `delete[]` on it → **heap corruption at XML load**, every game.

## Detection
Caught precisely under **App Verifier / full page heap (gflags)** as an invalid free of the page-heap fill value inside `~CvCivilizationInfo`, on the call stack `LoadPreMenuGlobals → LoadGlobalClassInfo<CvCivilizationInfo> → SetGlobalClassInfo → ~CvCivilizationInfo`. Without page heap the freed pointer is usually 0/benign, so it silently corrupts rather than crashing deterministically.

## Fix
Add `m_paiPeakYieldChange(NULL)` to the constructor init-list (one line), matching its siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)