### PR TITLE
Fix uninitialized read on missing GlobalDefine (spurious "in Info class was incorrect" popup)

### DIFF
--- a/NoCrash DLL SourceCode/CvXMLLoadUtility.cpp
+++ b/NoCrash DLL SourceCode/CvXMLLoadUtility.cpp
@@ -349,6 +349,15 @@ bool CvXMLLoadUtility::SkipToNextVal()
 //------------------------------------------------------------------------------------------------------
 int CvXMLLoadUtility::FindInInfoClass(const TCHAR* pszVal, bool hideAssert)
 {
+	// A missing GlobalDefine (or any unresolved optional reference) leaves the
+	// caller's string pointer NULL; treat that as NONE rather than dereferencing
+	// uninitialized memory (which page heap exposes as a bogus "Tag ... was
+	// incorrect" XML-error popup).
+	if (pszVal == NULL)
+	{
+		return -1;
+	}
+
 	int idx = GC.getInfoTypeForString(pszVal, hideAssert);
 
 	// if we found a match in the list we will return the value of the loop counter

--- a/NoCrash DLL SourceCode/CvXMLLoadUtility.h
+++ b/NoCrash DLL SourceCode/CvXMLLoadUtility.h
@@ -363,7 +363,7 @@ private:
 #ifdef _USRDLL
 	template <class T>
 		void SetGlobalDefine(const char* szDefineName, T*& piDefVal)
-	{ GC.getDefinesVarSystem()->GetValue(szDefineName, piDefVal); }
+	{ if (!GC.getDefinesVarSystem()->GetValue(szDefineName, piDefVal)) piDefVal = NULL; }
 #endif
 	//
 	// template which can handle all info classes


### PR DESCRIPTION
## Problem
`CvXMLLoadUtility::SetPostGlobalsGlobalDefines()` resolves ~59 GlobalDefines to info-class indices with the pattern:
```cpp
SetGlobalDefine(name, szVal);
idx = FindInInfoClass(szVal);
```
The `SetGlobalDefine` template wrapper is `void` and **discards `FVariableSystem::GetValue()`'s success/fail bool**:
```cpp
template <class T> void SetGlobalDefine(const char* szDefineName, T*& piDefVal)
{ GC.getDefinesVarSystem()->GetValue(szDefineName, piDefVal); }
```
So when a define is **absent** (e.g. `MISCAST_PROMOTION`, undefined in some installs), `szVal` is left pointing at uninitialized memory and passed straight to `FindInInfoClass` → `getInfoTypeForString` reads garbage → returns `-1` → `"Tag: <garbage> in Info class was incorrect"` MessageBox.

## Detection
Caught under App Verifier / page heap: `pszVal` pointed at page-heap fill bytes (`0xf0…`). Under the normal heap that memory is usually zero/benign, so the warning only appears under gflags — but it's a real uninitialized read regardless. (The "Current XML file is …" line in the popup is `getCurrentXMLFile()` and is **stale/misleading** — it blamed an unrelated module file; the real failing lookup is in global-defines post-processing.)

## Fix (covers all 59 lookups, 2 edits)
- `SetGlobalDefine` NULLs the out-pointer when `GetValue` reports the define is absent.
- `FindInInfoClass` returns `-1` (NONE) for a NULL pointer instead of dereferencing it.

A missing define now resolves cleanly to NONE — identical to normal-heap behaviour — with no garbage read and no popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)