### PR TITLE
Fix OOB read in CvUnitInfo::copyNonDefaults name/quote/image merge (garbage unit names)

### DIFF
--- a/NoCrash DLL SourceCode/CvInfos.cpp
+++ b/NoCrash DLL SourceCode/CvInfos.cpp
@@ -18392,7 +18392,7 @@ void CvUnitInfo::copyNonDefaults(CvUnitInfo* pClassInfo, CvXMLLoadUtility* pXML)
 		for(int i = 0; i < pClassInfo->getNumUnitNames(); ++i)
 		{
 			bool bLoad = true;
-			for(int j = 0; i < getNumUnitNames(); ++i)
+			for(int j = 0; j < getNumUnitNames(); ++j)
 			{
 				if(pClassInfo->getUnitNames(i) == cDefault || pClassInfo->getUnitNames(i) == getUnitNames(j))
 				{
@@ -18425,7 +18425,7 @@ void CvUnitInfo::copyNonDefaults(CvUnitInfo* pClassInfo, CvXMLLoadUtility* pXML)
 		for(int i = 0; i < pClassInfo->getNumQuotes(); ++i)
 		{
 			bool bLoad = true;
-			for(int j = 0; i < getNumQuotes(); ++i)
+			for(int j = 0; j < getNumQuotes(); ++j)
 			{
 				if(pClassInfo->getQuotes(i) == cDefault || pClassInfo->getQuotes(i) == getQuotes(j))
 				{
@@ -18458,7 +18458,7 @@ void CvUnitInfo::copyNonDefaults(CvUnitInfo* pClassInfo, CvXMLLoadUtility* pXML)
 		for(int i = 0; i < pClassInfo->getNumImages(); ++i)
 		{
 			bool bLoad = true;
-			for(int j = 0; i < getNumImages(); ++i)
+			for(int j = 0; j < getNumImages(); ++j)
 			{
 				if(pClassInfo->getImages(i) == cDefault || pClassInfo->getImages(i) == getImages(j))
 				{


### PR DESCRIPTION
## Problem
The three dedup loops in `CvUnitInfo::copyNonDefaults` that merge a parent unit's **UnitNames / Quotes / Images** into the child during modular XML inheritance share an identical copy-paste typo — the inner loop tests and increments the **outer** index `i` instead of the inner `j`:
```cpp
for(int j = 0; i < getNumUnitNames(); ++i)   // should be: j < getNumUnitNames(); ++j
for(int j = 0; i < getNumQuotes(); ++i)      // should be: j < getNumQuotes(); ++j
for(int j = 0; i < getNumImages(); ++i)      // should be: j < getNumImages(); ++j
```
When the child already has ≥1 entry, the inner loop drives `i` past `pClassInfo->getNumX()`, so `pClassInfo->getUnitNames(i)` / `getQuotes(i)` / `getImages(i)` read **out of bounds** and push garbage into the merged array. The unit's `m_paszUnitNames` / `m_paszQuotes` / `m_paszImages` then hold garbage entries.

## Symptom
A hero/image unit's creation popup — `"<Player> has created <name> (<type>)!"` plus its quote — displayed a **garbage name and quote** (e.g. `ddddddddd… (Healer)`).

## Detection
Caught under App Verifier / page heap, where the OOB read returns poison. Under the normal heap it hits benign adjacent bytes, so it only manifests under gflags — but it's a real OOB read either way and corrupts the merged arrays regardless of heap.

## Fix
Correct all three inner loops to `for(int j = 0; j < getNumX(); ++j)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)