### PR TITLE
Fix Kuriotate city-count cap blocking palaces (Forbidden/Winter Palace)

### DIFF
--- a/NoCrash DLL SourceCode/CvGameTextMgr.cpp
+++ b/NoCrash DLL SourceCode/CvGameTextMgr.cpp
@@ -22675,7 +22675,7 @@ void CvGameTextMgr::buildBuildingRequiresString(CvWStringBuffer& szBuffer, Build
 				szBuffer.append(gDLL->getText("TXT_KEY_BUILDING_REQUIRES_NUM_CITIES", kBuilding.getNumCitiesPrereq()));
 			}
 /**								----  End Original Code  ----									**/
-			if (NO_PLAYER == ePlayer || ((GET_PLAYER(ePlayer).getMaxCities() != -1 && (GET_PLAYER(ePlayer).getMaxCities() < kBuilding.getNumCitiesPrereq())) ? (GET_PLAYER(ePlayer).getNumCities() < GET_PLAYER(ePlayer).getMaxCities()): GET_PLAYER(ePlayer).getNumCities() < kBuilding.getNumCitiesPrereq()))
+			if (NO_PLAYER == ePlayer || ((GET_PLAYER(ePlayer).getMaxCities() != -1 && (GET_PLAYER(ePlayer).getMaxCities() < kBuilding.getNumCitiesPrereq())) ? ((GET_PLAYER(ePlayer).getNumCities() - GET_PLAYER(ePlayer).getNumSettlements()) < GET_PLAYER(ePlayer).getMaxCities()): GET_PLAYER(ePlayer).getNumCities() < kBuilding.getNumCitiesPrereq()))
 			{
 				szBuffer.append(NEWLINE);
 				szBuffer.append(gDLL->getText("TXT_KEY_BUILDING_REQUIRES_NUM_CITIES", (NO_PLAYER == ePlayer ? (kBuilding.getNumCitiesPrereq()) : ((GET_PLAYER(ePlayer).getMaxCities() != -1 && (GET_PLAYER(ePlayer).getMaxCities() < kBuilding.getNumCitiesPrereq())) ? (GET_PLAYER(ePlayer).getMaxCities()) : kBuilding.getNumCitiesPrereq()))));

--- a/NoCrash DLL SourceCode/CvPlayer.cpp
+++ b/NoCrash DLL SourceCode/CvPlayer.cpp
@@ -8366,7 +8366,11 @@ bool CvPlayer::canConstruct(BuildingTypes eBuilding, bool bContinue, bool bTestV
 /**								---- Start Original Code ----									**
 		if (getNumCities() < GC.getBuildingInfo(eBuilding).getNumCitiesPrereq())
 /**								----  End Original Code  ----									**/
-		if (getNumCities() < GC.getBuildingInfo(eBuilding).getNumCitiesPrereq() || (getMaxCities() != -1 && (getMaxCities() < GC.getBuildingInfo(eBuilding).getNumCitiesPrereq()) && (getNumCities() != getMaxCities())))
+/**	Settlement-count fix: getMaxCities() caps only full cities, but getNumCities() also		**/
+/**	counts settlements, so getNumCities()==getMaxCities() was unreachable for any Kuriotate	**/
+/**	with a settlement, permanently blocking buildings whose prereq exceeds the cap.			**/
+/**	Compare the real-city count (getNumCities()-getNumSettlements()), matching CvCity.cpp.	**/
+		if (getNumCities() < GC.getBuildingInfo(eBuilding).getNumCitiesPrereq() || (getMaxCities() != -1 && (getMaxCities() < GC.getBuildingInfo(eBuilding).getNumCitiesPrereq()) && ((getNumCities() - getNumSettlements()) != getMaxCities())))
 /*************************************************************************************************/
 /**	Tweak									END													**/
 /*************************************************************************************************/


### PR DESCRIPTION
## Problem

A Kuriotate player who has founded their full set of cities (e.g. 4 on a Large map) plus settlements — 12 cities total — still cannot build the **Forbidden Palace** (`iCitiesPrereq` 8) or **Winter Palace** (`iCitiesPrereq` 12). The buildings are never offered, regardless of how many cities/settlements exist.

## Root cause

The Xienwolf *"Fixes Kuriotates on small maps for certain buildings"* tweak in `CvPlayer::canConstruct` gates the building behind:

```cpp
getMaxCities() != -1 && getMaxCities() < prereq && getNumCities() != getMaxCities()
```

`getMaxCities()` caps only **full** cities. `getNumCities()` counts **settlements too** — `CvCity::init` itself uses `getNumCities() - getNumSettlements()` as the real-city count when deciding whether a newly founded city becomes a settlement.

So once a Kuriotate founds even one settlement, `getNumCities() == getMaxCities()` becomes unreachable, the clause stays permanently true, and every building whose `iCitiesPrereq` exceeds the city cap is permanently unbuildable.

Concrete: Kuriotate cap = trait `iMaxCities` 3 + worldsize `iMaxCitiesMod` (+1 on Large) = **4**. With 4 real + 8 settlements: `getNumCities()` = 12, `getMaxCities()` = 4 → `12 != 4` is always true → blocked. Forbidden Palace (8) and Winter Palace (12) both fail.

## Fix

Compare the **real-city count** (`getNumCities() - getNumSettlements()`) against `getMaxCities()`, matching the founding logic in `CvCity.cpp`. Now the clause clears once the player has founded all their full cities, and the palace unlocks when total cities also meet the prereq. `CvGameTextMgr`'s matching *"requires N cities"* tooltip is corrected the same way so the help text agrees with the rule.

- `CvPlayer.cpp` — `canConstruct` prereq gate
- `CvGameTextMgr.cpp` — `buildBuildingRequiresString` tooltip

Behavior for non-capped civs (`getMaxCities() == -1`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)