### PR TITLE
Hide second-government-center buttons (Forbidden/Winter Palace) in gov-center cities

### DIFF
--- a/Assets/python/Screens/CvMainInterface.py
+++ b/Assets/python/Screens/CvMainInterface.py
@@ -2643,6 +2643,11 @@ class CvMainInterface:
 					if (not isLimitedWonderClass(i)):
 						eLoopBuilding = pHeadSelectedCity.getCityBuildings(i)
 
+						# UI: a city that is already a government center cannot build a second one
+						# (Forbidden Palace / Winter Palace) - don't offer the button in such cities.
+						if (eLoopBuilding != -1 and gc.getBuildingInfo(eLoopBuilding).isGovernmentCenter() and pHeadSelectedCity.isGovernmentCenter()):
+							continue
+
 						if (pHeadSelectedCity.canConstruct(eLoopBuilding, False, True, False)):
 # High Res stuff - Modified by Grey Fox 03/29/2010
 							screen.appendMultiListButton( eMultiList, gc.getBuildingInfo(eLoopBuilding).getButton(), iRow, WidgetTypes.WIDGET_CONSTRUCT, i, -1, False )
@@ -2671,6 +2676,11 @@ class CvMainInterface:
 				for i in xrange( g_NumBuildingClassInfos ):
 					if (isLimitedWonderClass(i)):
 						eLoopBuilding = gc.getCivilizationInfo(pHeadSelectedCity.getCivilizationType()).getCivilizationBuildings(i)
+
+						# UI: a city that is already a government center cannot build a second one
+						# (Forbidden Palace / Winter Palace) - don't offer the button in such cities.
+						if (eLoopBuilding != -1 and gc.getBuildingInfo(eLoopBuilding).isGovernmentCenter() and pHeadSelectedCity.isGovernmentCenter()):
+							continue
 
 						if (pHeadSelectedCity.canConstruct(eLoopBuilding, False, True, False)):
 # High Res stuff - Modified by Grey Fox 03/29/2010


### PR DESCRIPTION
## What

In the city screen, the **Forbidden Palace** and **Winter Palace** buttons appear in the capital even though they can't be built there (a city that already holds a government center — the per-civ Palace — can't build a second one). They show as a dead, grayed button.

## Why it happens

`CvMainInterface.py` builds the construction list by appending a button whenever `canConstruct(..., bTestVisible=True, ...)` passes, then only *graying* it when the full `canConstruct(..., False, ...)` check fails:

```python
if (pHeadSelectedCity.canConstruct(eLoopBuilding, False, True, False)):
    screen.appendMultiListButton(...)
    if (not pHeadSelectedCity.canConstruct(eLoopBuilding, False, False, False)):
        screen.disableMultiListButton(...)
```

Government-center buildings (`bGovernmentCenter=1`: Forbidden Palace, Winter Palace, Minster, Council of the Warchief) can never be built in a government-center city — `CvCity::canConstruct` returns false for an `isGovernmentCenter()` building in an `isGovernmentCenter()` city. The result is a permanently disabled button being offered in the capital.

## Change

In both the buildings loop and the wonders loop, skip appending the button for a government-center building when the selected city is already a government center:

```python
if (eLoopBuilding != -1 and gc.getBuildingInfo(eLoopBuilding).isGovernmentCenter() and pHeadSelectedCity.isGovernmentCenter()):
    continue
```

Pure UI change that mirrors the engine's own construct rule. `CyCity.isGovernmentCenter()` and `CyBuildingInfo.isGovernmentCenter()` are both exposed to Python. No DLL change required — `CvCity::canConstruct` already enforces the rule; this only stops offering a button that can never be enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)